### PR TITLE
add toggle for monsters only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ target/original-MobPreventer-1.0.0-SNAPSHOT.jar
 >>>>>>> Stashed changes
 *.class
 *.jar
+.idea/

--- a/MobPreventer.iml
+++ b/MobPreventer.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" version="4">
+<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet type="minecraft" name="Minecraft">
       <configuration>
@@ -15,13 +15,11 @@
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.spigotmc:spigot-api:1.16.3-R0.1-SNAPSHOT" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.spigotmc:spigot-api:1.16.4-R0.1-SNAPSHOT" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: commons-lang:commons-lang:2.6" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.guava:guava:21.0" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.code.gson:gson:2.8.0" level="project" />

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.Tofpu</groupId>
     <artifactId>MobPreventer</artifactId>
-    <version>1.0.9-SNAPSHOT</version>
+    <version>1.0.10-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>MobPreventer</name>
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.16.3-R0.1-SNAPSHOT</version>
+            <version>1.16.4-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/me/tofpu/mobpreventer/config/Config.java
+++ b/src/main/java/me/tofpu/mobpreventer/config/Config.java
@@ -13,6 +13,7 @@ public class Config {
     private boolean reverse;
     private boolean perWorld;
     private boolean spawners;
+    private boolean monstersOnly;
     
     public Config(MobPreventer mobPreventer) {
         this.mobPreventer = mobPreventer;
@@ -29,6 +30,8 @@ public class Config {
         this.perWorld = mobPreventer.getConfig().getBoolean("settings.per-world");
 
         this.spawners = mobPreventer.getConfig().getBoolean("settings.enable-spawners");
+
+        this.monstersOnly = mobPreventer.getConfig().getBoolean("settings.monsters-only");
     }
     
     public void reload(){
@@ -42,6 +45,7 @@ public class Config {
         this.reverse = this.mobPreventer.getConfig().getBoolean("settings.reverse");
         this.perWorld = this.mobPreventer.getConfig().getBoolean("settings.per-world");
         this.spawners = mobPreventer.getConfig().getBoolean("settings.enable-spawners");
+        this.monstersOnly = this.mobPreventer.getConfig().getBoolean("settings.monsters-only");
     }
     
     public Set<String> getBlacklist() {
@@ -66,5 +70,9 @@ public class Config {
     
     public boolean isSpawnersEnabled() {
         return spawners;
+    }
+
+    public boolean isMonstersOnly() {
+        return monstersOnly;
     }
 }

--- a/src/main/java/me/tofpu/mobpreventer/listeners/CreatureSpawnListener.java
+++ b/src/main/java/me/tofpu/mobpreventer/listeners/CreatureSpawnListener.java
@@ -19,6 +19,16 @@ public class CreatureSpawnListener implements Listener {
         final Config config = mobPreventer.getStaticConfig();
         final String type = e.getEntityType().toString().replace("_", "").toLowerCase();
 
+        // If Entity is not of interface type Monster then do not proceed.
+        // Type Monster may be in first or second-level interface.
+        if (config.isMonstersOnly()) {
+            final String interface0 = e.getEntity().getClass().getSuperclass().getInterfaces()[0].getSimpleName();
+            final String interface1 = e.getEntity().getClass().getSuperclass().getInterfaces()[0].getInterfaces()[0].getSimpleName();
+            if (!interface0.equalsIgnoreCase("Monster") && !interface1.equalsIgnoreCase("Monster")) {
+                return;
+            }
+        }
+
         if (!config.isSpawnersEnabled()){
             if (e.getSpawnReason() == CreatureSpawnEvent.SpawnReason.SPAWNER){
                 return;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -22,6 +22,10 @@ settings:
   worlds:
   - "example-world"
 
+  # If monsters-only is set to true, it'll only account for 33 Monster type mobs. (Zombie, Witch, etc.)
+  # If monsters-only is set to false, it'll account for all 81 mobs. (Zombie, NPC, Cat, Squid, Chicken, etc.)
+  # 1.16.4 list available here: https://gist.github.com/nanohard/3cce0fa547e70f33969f5debccab3992
+  monsters-only: true
 
   # If reverse is set to false. it'll blacklist mobs which are listed below.
   blacklist:


### PR DESCRIPTION
This link shows the difference between [Monsters vs Creatures](https://gist.github.com/nanohard/3cce0fa547e70f33969f5debccab3992)

I've added a boolean in the config so users can choose between all Creatures, or Monsters only. Being as this plugin is named **MobPreventer** I didn't want to exclude all Creatures, as some may have a need to blacklist Creatures that are not Monsters. But the majority of people, in my opinion, only want to work with Monsters.

**true** is the default value of **monstersOnly**, meaning that the blacklist/whitelist will only consider Monsters. Changing it to **false** will make the plugin consider all Creatures.